### PR TITLE
Upgrade to pysteps 1.2 with minor QoL fixes.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7
+  - python>=3.7
   - git
   - numpy
+  - scipy
   - h5py
   - pillow
+  - pysteps>=1.2
   - dask
   - pyfftw
-  - pysteps=1.1.1

--- a/fmippn/CHANGELOG.md
+++ b/fmippn/CHANGELOG.md
@@ -3,9 +3,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-This project DOES NOT adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Instead, version numbering will be a running number. Each major number increases when a dependency module is upgraded, added, or removed (e.g. pysteps). Each minor number increases when a research version is updated, either by RAS or PAK.
+Currently this project DOES NOT adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v3.0] - 2020-01-29
+## 2020-04-17
+### Added
+- Parameter for calculation domain ("spatial" or "spectral")
+- `scipy` to `environment.yml`
+
+### Changed
+- Updated README.md
+- Configuration files can now be stored anywhere, as long as full path is used for `-c` parameter values
+- Updated requirement for `python` (Used to be `=3.7`, now is `>=3.7`)
+- Updated requirement for `pysteps` (Used to be `=1.1`, now is `>=1.2`)
+- Moved `environment.yml` to main folder
+- `-t` is now shorthand for `--timestamp` command line argument
+
+### Removed
+- References to version numbers from changelog, as they don't reflect the current situation anymore
+- Obsolete `--test` command line argument
+
+## 2020-01-29
 ### Added
 - Folder for configuration files
 - Utility functions for generating a configuration json file
@@ -26,7 +43,7 @@ This project DOES NOT adhere to [Semantic Versioning](https://semver.org/spec/v2
 - Input data is now thresholded properly
 - Now it is possible to output values in mm/h, even if calculations are done in dBZ
 
-## [v2.1] - 2019-12-20
+## 2019-12-20
 ### Added
 - New parametrisations and configurations for operational use
 - Usage and Configuration descriptions to readme
@@ -47,7 +64,7 @@ This project DOES NOT adhere to [Semantic Versioning](https://semver.org/spec/v2
 - Removed unused import from `utils`
 - Version tag links in changelog
 
-## [v2.0] - 2019-09-02
+## 2019-09-02
 ### Added
 - Changelog
 - New dependency: pysteps (1.0.0)
@@ -70,7 +87,7 @@ This project DOES NOT adhere to [Semantic Versioning](https://semver.org/spec/v2
 ### Removed
 - Extra dependencies that were unused or no longer needed
 
-## [v1.1] - 2019-05-06
+## 2019-05-06
 ### Added
 - New parameters: `SEED`, `ZR_A`, `ZR_B`, `SCALE_ZERO`, `SCALER`, `FIELD_VALUES`
 - Now it is possible to set random number generator seed via `SEED` parameter
@@ -79,18 +96,11 @@ This project DOES NOT adhere to [Semantic Versioning](https://semver.org/spec/v2
 - Scaling parameter in output file can now be set via parameter `SCALER`
 - Scaling offset in output file can now be set via `SCALE_ZERO` parameter
 - Program uses nowcast data array's minimum non-NaN value as scaling offset, unless given via configuration parameters
-- Parameters `SEED` and `FIELD_VALUES` are stored in output file`s metadata
+- Parameters `SEED` and `FIELD_VALUES` are stored in output file's metadata
 
 ### Changed
 - "Valid for" attribute in output file is now an integer (was: string)
 - `OUTPUT_TIME_FORMAT` parameter no longer affects the "Valid for" attribute
 
-## [v1.0] - 2019-01-22
+## 2019-01-22
 - First prototype version given to operational testing
-
-[v3.0]: https://github.com/fmidev/fmippn/compare/v2.1...v3.0
-[v2.1]: https://github.com/fmidev/fmippn/compare/v2.0...v2.1
-[v2.0]: https://github.com/fmidev/fmippn/compare/v1.1...v2.0
-[v1.1]: https://github.com/fmidev/fmippn/compare/v1.0...v1.1
-[v1.0]: https://github.com/fmidev/fmippn/releases/tag/v1.0
-

--- a/fmippn/README.md
+++ b/fmippn/README.md
@@ -10,7 +10,10 @@ Currently FMI-PPN uses [pysteps](https://pysteps.github.io) to generate ensemble
 
 ## Known issues and limitations
 - Parameter `SEED` must be `None` or an integer between `0` and `2**32 - 1`. This is a limitation in `numpy.random`.
-- OpenMPI conflicts with dask when both are installed, leading to significant decrease FMI-PPN performance. Workaround is to set OpenMPI use only one thread. In Linux you can set environment variable `OMP_NUM_THREADS=1`.
+- OpenMPI conflicts with dask when both are installed, leading to significant decrease FMI-PPN performance.
+  - Workaround is to set OpenMPI use only one thread. In Linux you can set environment variable `OMP_NUM_THREADS=1`.
+  - Alternatively: uninstall `dask` from conda environment
+- `pyfftw <0.12.0` is incompatible with `scipy 1.4`.
 
 ## Usage
 ### Installation
@@ -24,7 +27,7 @@ Currently FMI-PPN uses [pysteps](https://pysteps.github.io) to generate ensemble
 8. Run FMI-PPN with default settings: `$ python run_ppn.py`
 
 ### Running FMI-PPN
-Before running FMI-PPN, you should configure pysteps (via `pystepsrc` file) and PPN by adding your parametrisations to `ppn_config.py`.
+Before running FMI-PPN, you should configure pysteps (via `pystepsrc` file) and PPN by adding your parametrisations to a config file (see below).
 
 How to run:
 1. Activate your conda environment
@@ -39,6 +42,7 @@ The `ppn_config.py` module has a utility function `dump_defaults()` for creating
 ### Parametrisations
 Parameter|Explanation|Default value
 ----|----|----
+`CALCULATION_DOMAIN`|Choose if the nowcast calculation is performed in spatial (`spatial`) or spectral (`spectral`) domain. See also [pysteps documentation](https://pysteps.readthedocs.io/en/latest/generated/pysteps.nowcasts.steps.forecast.html#pysteps.nowcasts.steps.forecast).|`spectral`
 `DOMAIN`|Data source used from pystepsrc|`fmi`
 `ENSEMBLE_SIZE`|Number of ensemble members|`24`
 `FFT_METHOD`|FFT method used in pysteps calculations|`pyfftw`

--- a/fmippn/ppn.py
+++ b/fmippn/ppn.py
@@ -33,15 +33,9 @@ def run(timestamp=None, config=None, **kwargs):
         config -- Configuration parameter. If None, use defaults. (default=None)
 
     Optional keyword arguments:
-        test -- If True, use development configuration (default=False)
+        (none)
     """
     nc_fname = None
-
-    if kwargs.get("test", False):
-        # Use frontal precipitation event (verification) for development
-        config = "test"
-        timestamp = "201506231400"
-        nc_fname = "00_test_output.h5"  # Development name for output file
 
     PD.update(get_config(config))
 
@@ -285,6 +279,7 @@ def generate_pysteps_setup():
         "vel_pert_method": PD["VEL_PERT_METHOD"],
         "vel_pert_kwargs": PD["VEL_PERT_KWARGS"],
         "seed": PD["SEED"],
+        "domain": PD.get("CALCULATION_DOMAIN", "spatial")
     }
 
     # This threshold is used in masking and probability masking

--- a/fmippn/ppn_config.py
+++ b/fmippn/ppn_config.py
@@ -19,6 +19,7 @@ generating the file is to run following command on command line:
 """
 import logging
 import json
+import os
 
 def get_params(name):
     """Utility function for easier access to wanted parametrizations.
@@ -40,8 +41,16 @@ def get_params(name):
     if name == "defaults":
         params = defaults
     else:
+        name = os.path.splitext(name)[0] + ".json"
+        if os.path.exists(name):
+            cfname = name
+        else:
+            cfpath = os.path.realpath(__file__)
+            cfpath = os.path.split(cfpath)[0]
+            cfname = os.path.join(cfpath, "config/", name)
+        print(f"Using PPN configuration from {cfname}")
         try:
-            with open(f"config/{name}.json", "r") as f:
+            with open(cfname, "r") as f:
                 params = json.load(f)
         except FileNotFoundError:
             params = dict()
@@ -92,6 +101,7 @@ defaults = {
     "NORAIN_VALUE": 1.5,  # Threshold minus 5 (dB) units. Roughly 0.04 mm/h using above
     "KMPERPIXEL": 1.0,
     "SEED": None,  # Default value in pysteps is None
+    "CALCULATION_DOMAIN": "spectral",  # "spatial" or "spectral", see also pysteps.nowcasts.steps() documentation
     # Motion perturbation parameters
     # Set to VEL_PERT_KWARGS to `None` to use pysteps's default values
     "VEL_PERT_METHOD": "bps",

--- a/fmippn/run_ppn.py
+++ b/fmippn/run_ppn.py
@@ -22,10 +22,8 @@ def get_input_arguments():
     # Add more options if necessary
     parser = argparse.ArgumentParser(description="Command line interface for FMI-PPN")
     parser.add_argument("-c", "--config", help="Select configuration settings")
-    parser.add_argument("--timestamp", help="Nowcast initialization time",
+    parser.add_argument("-t", "--timestamp", help="Nowcast initialization time",
                         metavar="YYYYMMDDHHMM")
-    parser.add_argument("-t", "--test", action="store_true",
-                        help="Run using development parameters")
 
     return vars(parser.parse_args())
 


### PR DESCRIPTION
Highlights:
- environment.yml updated to use pysteps>=1.2
- Now can choose spectral domain in pysteps.nowcast.steps